### PR TITLE
fix: jwt Access Token 재발급에 있어 잘못된 사항 수정

### DIFF
--- a/src/main/java/com/hanghae/greenstep/member/MemberController.java
+++ b/src/main/java/com/hanghae/greenstep/member/MemberController.java
@@ -22,7 +22,7 @@ public class MemberController {
     }
 
     @PostMapping("/refresh-token")
-    public ResponseEntity<?> refreshTokenCheck(@RequestBody String nickname, HttpServletRequest request, HttpServletResponse response){
-        return memberService.refreshToken(nickname, request, response);
+    public ResponseEntity<?> refreshTokenCheck(HttpServletRequest request, HttpServletResponse response){
+        return memberService.refreshToken(request, response);
     }
 }

--- a/src/main/java/com/hanghae/greenstep/member/MemberService.java
+++ b/src/main/java/com/hanghae/greenstep/member/MemberService.java
@@ -12,60 +12,41 @@ import com.hanghae.greenstep.shared.Message;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
-
-    private final MemberRepository memberRepository;
-
-    private final PasswordEncoder passwordEncoder;
-
     private final TokenProvider tokenProvider;
-
     private final RefreshTokenRepository refreshTokenRepository;
-
     private final Check check;
 
 
-    public void tokenToHeaders(TokenDto tokenDto, HttpServletResponse response) {
-        response.addHeader("Authorization", "Bearer " + tokenDto.getAccessToken());
-        response.addHeader("Refresh-Token", tokenDto.getRefreshToken());
-        response.addHeader("Access-Token-Expire-Time", tokenDto.getAccessTokenExpiresIn().toString());
-    }
+    public ResponseEntity<?> refreshToken( HttpServletRequest request, HttpServletResponse response) {
+        tokenProvider.validateToken(request.getHeader("Refresh-Token"));
+        Member requestingMember = validateMember(request);
+        long accessTokenExpire = Long.parseLong(request.getHeader("Access-Token-Expire-Time"));
+        long now = (new Date().getTime());
+        if (now>accessTokenExpire){
+            tokenProvider.deleteRefreshToken(requestingMember);
+            throw new CustomException(ErrorCode.INVALID_TOKEN);}
 
-    public ResponseEntity<?> refreshToken(String nickname, HttpServletRequest request, HttpServletResponse response) {
-        if (null == request.getHeader("Refresh-Token")) {
-            throw new CustomException(ErrorCode.INVALID_TOKEN);
-        }
-        Member requestingMember = memberRepository.findByNickname(nickname).orElse(null);
-        if (requestingMember == null) {
-            throw new CustomException(ErrorCode.INVALID_MEMBER_INFO);
-        }
         RefreshToken refreshTokenConfirm = refreshTokenRepository.findByMember(requestingMember).orElse(null);
         if (refreshTokenConfirm == null) {
-            throw new CustomException(ErrorCode.INVALID_TOKEN);
-        }
-        LocalDateTime currentDateTime = LocalDateTime.now();
-        if (!refreshTokenConfirm.getCreatedAt().plusHours(3).equals(currentDateTime)) {
             throw new CustomException(ErrorCode.REFRESH_TOKEN_IS_EXPIRED);
-        }//고려
+        }
         if (Objects.equals(refreshTokenConfirm.getValue(), request.getHeader("Refresh-Token"))) {
-            TokenDto tokenDto = tokenProvider.generateTokenDto(requestingMember);
+            TokenDto tokenDto = tokenProvider.generateAccessTokenDto(requestingMember);
             accessTokenToHeaders(tokenDto, response);
             return new ResponseEntity<>(Message.success("ACCESS_TOKEN_REISSUE"), HttpStatus.OK);
         } else {
-            tokenProvider.deleteRefreshToken(memberRepository.findByNickname(nickname).orElseThrow(
-                    () -> new CustomException(ErrorCode.INVALID_TOKEN))
-            );
-            throw new CustomException(ErrorCode.INVALID_MEMBER_INFO);
+            tokenProvider.deleteRefreshToken(requestingMember);
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
         }
     }
     public void accessTokenToHeaders(TokenDto tokenDto, HttpServletResponse response) {
@@ -79,5 +60,10 @@ public class MemberService {
     return new ResponseEntity<>(Message.success(null),HttpStatus.OK);
     }
 
-
+    public Member validateMember(HttpServletRequest request) {
+        if (!tokenProvider.validateToken(request.getHeader("Refresh-Token"))) {
+            return null;
+        }
+        return tokenProvider.getMemberFromAuthentication();
+    }
 }


### PR DESCRIPTION
fix: jwt Refresh Token을 통한 AccessToken 재발급시 Refresh토큰을 재발급하는 코드를 삭제하고 Access토큰과 Access토큰 만료 시간만  발급하는 방식으로 코드 수정