### PR TITLE
fix: 원활한 api 테스트를 위한 엑세스 토큰 유효기간 3일로 변경 임시 추가

### DIFF
--- a/src/main/java/com/hanghae/greenstep/jwt/TokenProvider.java
+++ b/src/main/java/com/hanghae/greenstep/jwt/TokenProvider.java
@@ -28,7 +28,7 @@ public class TokenProvider {
 
     private static final String AUTHORITIES_KEY = "auth";
     private static final String BEARER_PREFIX = "Bearer ";
-    public static final long ACCESS_TOKEN_EXPIRE_TIME = 10800000;
+    public static final long ACCESS_TOKEN_EXPIRE_TIME = 304800000;
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 604800000;
 
     private final Key key;


### PR DESCRIPTION
#67 