### PR TITLE
feat: 로그아웃, 회원탈퇴 기능 추가

### DIFF
--- a/src/main/java/com/hanghae/greenstep/admin/AdminService.java
+++ b/src/main/java/com/hanghae/greenstep/admin/AdminService.java
@@ -69,6 +69,7 @@ public class AdminService {
 
     //n+1 문제 없음
     public ResponseEntity<?> login(AdminLoginRequestDto adminLoginRequestDto, HttpServletResponse response) {
+        blockSqlSentence(adminLoginRequestDto);
         Member admin = memberRepository.findByEmailAndRole(adminLoginRequestDto.getEmail(), ROLE_ADMIN).orElseThrow(
                 () -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
         if (!admin.validatePassword(passwordEncoder, adminLoginRequestDto.getPassword())) {
@@ -114,5 +115,12 @@ public class AdminService {
         if (Objects.equals(submitMission.getMission().getMissionType(), "weekly"))
             submitMission.getMember().earnWeeklyPoint();
         submitMission.getMember().earnChallengePoint();
+    }
+
+    public void blockSqlSentence(AdminLoginRequestDto requestDto) {
+        if (!requestDto.getEmail().matches("[a-zA-Z\\d]{3,15}@[a-zA-Z\\d]{3,15}[.][a-zA-Z]{2,5}")||
+                requestDto.getPassword().matches("^(?=./*[A-Za-z\\d@$!%*#?&]){4,18}$")){
+             throw new CustomException(ErrorCode.BAD_REQUEST);
+        }
     }
 }

--- a/src/main/java/com/hanghae/greenstep/clap/Clap.java
+++ b/src/main/java/com/hanghae/greenstep/clap/Clap.java
@@ -17,14 +17,13 @@ public class Clap {
     @GeneratedValue
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Member member;
+    private Long memberId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Feed feed;
 
     public Clap(ClapRequestDto clapRequestDto) {
-        if (clapRequestDto.getMember() != null) this.member = clapRequestDto.getMember();
+        if (clapRequestDto.getMember().getId() != null) this.memberId = clapRequestDto.getMember().getId();
         if (clapRequestDto.getFeed() != null) this.feed = clapRequestDto.getFeed();
     }
 }

--- a/src/main/java/com/hanghae/greenstep/clap/ClapRepository.java
+++ b/src/main/java/com/hanghae/greenstep/clap/ClapRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface ClapRepository extends JpaRepository<Clap,Long> {
-    boolean existsByMemberAndFeed(Member member, Feed feed);
-    Optional<Clap> findByMemberAndFeed(Member member, Feed feed);
+    boolean existsByMemberIdAndFeed(Long memberId, Feed feed);
+    Optional<Clap> findByMemberIdAndFeed(Long memberId, Feed feed);
     Integer countByFeed(Feed feed);
 }

--- a/src/main/java/com/hanghae/greenstep/clap/ClapService.java
+++ b/src/main/java/com/hanghae/greenstep/clap/ClapService.java
@@ -28,7 +28,7 @@ public class ClapService {
         Feed feed = feedRepository.findById(feedId).orElseThrow(
                 () -> new CustomException(ErrorCode.POST_NOT_FOUND));
 
-        Clap foundClap = clapRepository.findByMemberAndFeed(member,feed).orElse(null);
+        Clap foundClap = clapRepository.findByMemberIdAndFeed(member.getId(),feed).orElse(null);
 
         if(foundClap == null){
             ClapRequestDto clapRequestDto = new ClapRequestDto(member, feed);

--- a/src/main/java/com/hanghae/greenstep/feed/FeedService.java
+++ b/src/main/java/com/hanghae/greenstep/feed/FeedService.java
@@ -92,7 +92,7 @@ public class FeedService {
     public List<FeedResponseDto> makeFeedList(List<Feed> feedList, Member member){
         List<FeedResponseDto> feedResponseDtoList =new ArrayList<>();
         for (Feed feed : feedList) {
-            boolean clapByMe = clapRepository.existsByMemberAndFeed(member, feed);
+            boolean clapByMe = clapRepository.existsByMemberIdAndFeed(member.getId(), feed);
             feedResponseDtoList.add(
                     FeedResponseDto.builder()
                             .id(feed.getId())

--- a/src/main/java/com/hanghae/greenstep/jwt/RefreshTokenRepository.java
+++ b/src/main/java/com/hanghae/greenstep/jwt/RefreshTokenRepository.java
@@ -4,10 +4,12 @@ package com.hanghae.greenstep.jwt;
 import com.hanghae.greenstep.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import javax.swing.plaf.metal.MetalMenuBarUI;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken,Long> {
 
     Optional<RefreshToken> findByMember(Member member);
 
+    void deleteByMember(Member member);
 }

--- a/src/main/java/com/hanghae/greenstep/kakaoLogin/KakaoSocialController.java
+++ b/src/main/java/com/hanghae/greenstep/kakaoLogin/KakaoSocialController.java
@@ -9,24 +9,35 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 
 @RestController
 @RequiredArgsConstructor
-public class KakaoLoginController {
+public class KakaoSocialController {
 
-    private final KakaoLoginService kakaoLoginService;
+    private final KakaoSocialService kakaoSocialService;
 
     @Transactional
     @GetMapping("/users/kakao/callback")
     public ResponseEntity<?> kakaoLogin(@RequestParam String code, HttpServletResponse response) throws JsonProcessingException {
-        TokenDto tokenDto= kakaoLoginService.kakaoLogin(code);
+        TokenDto tokenDto= kakaoSocialService.kakaoLogin(code);
         tokenDto.tokenToHeaders(response);
-        LoginResponseDto loginResponseDto = kakaoLoginService.loginInfo(tokenDto);
+        LoginResponseDto loginResponseDto = kakaoSocialService.loginInfo(tokenDto);
         return new ResponseEntity<>(Message.success(loginResponseDto), HttpStatus.OK);
+    }
+
+    @GetMapping("/kakao/logout")
+    public ResponseEntity<?> kakaoLogout(HttpServletRequest request) throws JsonProcessingException {
+        return kakaoSocialService.kakaoLogout(request);
+    }
+    @PostMapping("/kakao/unregister")
+    public ResponseEntity<?> deleteMemberInfo(HttpServletRequest request) throws JsonProcessingException {
+        return kakaoSocialService.deleteMemberInfo(request);
     }
 }

--- a/src/main/java/com/hanghae/greenstep/kakaoLogin/KakaoSocialService.java
+++ b/src/main/java/com/hanghae/greenstep/kakaoLogin/KakaoSocialService.java
@@ -157,12 +157,13 @@ public class KakaoSocialService {
     }
 
 
+    @Transactional
     public ResponseEntity<?> kakaoLogout(HttpServletRequest request) throws JsonProcessingException {
         Member member = check.accessTokenCheck(request);
         HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = kakaoTokenHeaderMaker(request);
         RestTemplate rt = new RestTemplate();
         ResponseEntity<String> response = rt.exchange(
-                "https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code",
+                "https://kauth.kakao.com/oauth/authorize?client_id="+kakaoClientId+"&redirect_uri="+RedirectURI+"&response_type=code",
                 HttpMethod.GET,
                 kakaoTokenRequest,
                 String.class
@@ -170,11 +171,9 @@ public class KakaoSocialService {
         String responseBody = response.getBody();
         ObjectMapper objectMapper = new ObjectMapper();
         JsonNode jsonNode = objectMapper.readTree(responseBody);
-        Long kakaoId = jsonNode.get("id").asLong();
-        if(Objects.equals(member.getKakaoId(), kakaoId)) {
-            refreshTokenRepository.deleteByMember(member);
-            return new ResponseEntity<>(Message.success("로그아웃 되었습니다"), HttpStatus.OK);}
-        else throw new CustomException(ErrorCode.INVALID_TOKEN);
+        Long id = jsonNode.get("id").asLong();
+        if(Objects.equals(member.getKakaoId(), id)) refreshTokenRepository.deleteByMember(member);
+        return new ResponseEntity<>(Message.success(true), HttpStatus.OK);
     }
 
 
@@ -197,7 +196,7 @@ public class KakaoSocialService {
         Long kakaoId = jsonNode.get("id").asLong();
         if (Objects.equals(member.getKakaoId(), kakaoId)) {
             refreshTokenRepository.deleteByMember(member);
-            return new ResponseEntity<>(Message.success(memberId + "번 회원탈퇴처리가 정상적으로 처리되었습니다"), HttpStatus.OK);
+            return new ResponseEntity<>(Message.success(true), HttpStatus.OK);
         } else throw new CustomException(ErrorCode.INVALID_TOKEN);
     }
 

--- a/src/main/java/com/hanghae/greenstep/kakaoLogin/KakaoSocialService.java
+++ b/src/main/java/com/hanghae/greenstep/kakaoLogin/KakaoSocialService.java
@@ -6,28 +6,30 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hanghae.greenstep.exception.CustomException;
 import com.hanghae.greenstep.exception.ErrorCode;
+import com.hanghae.greenstep.jwt.RefreshTokenRepository;
 import com.hanghae.greenstep.jwt.TokenDto;
 import com.hanghae.greenstep.jwt.TokenProvider;
 import com.hanghae.greenstep.jwt.UserDetailsImpl;
 import com.hanghae.greenstep.member.Member;
 import com.hanghae.greenstep.member.MemberRepository;
+import com.hanghae.greenstep.shared.Check;
+import com.hanghae.greenstep.shared.Message;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -36,7 +38,7 @@ import static com.hanghae.greenstep.shared.Authority.ROLE_MEMBER;
 @RequiredArgsConstructor
 @Service
 @Slf4j
-public class KakaoLoginService {
+public class KakaoSocialService {
     @Value("${kakao.client_id}")
     String kakaoClientId;
     @Value("${kakao.redirect_uri}")
@@ -45,6 +47,8 @@ public class KakaoLoginService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final TokenProvider tokenProvider;
+    private final Check check;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     public TokenDto kakaoLogin(String code) throws JsonProcessingException {
         // 1. "인가 코드"로 "액세스 토큰" 요청
@@ -106,7 +110,6 @@ public class KakaoLoginService {
                 kakaoTokenRequest,
                 String.class
         );
-
         // HTTP 응답 (JSON) -> 액세스 토큰 파싱
         String responseBody = response.getBody();
         ObjectMapper objectMapper = new ObjectMapper();
@@ -152,5 +155,62 @@ public class KakaoLoginService {
                 .newComer(tokenDto.getNewComer())
                 .build();
     }
+
+
+    public ResponseEntity<?> kakaoLogout(HttpServletRequest request) throws JsonProcessingException {
+        Member member = check.accessTokenCheck(request);
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = kakaoTokenHeaderMaker(request);
+        RestTemplate rt = new RestTemplate();
+        ResponseEntity<String> response = rt.exchange(
+                "https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code",
+                HttpMethod.GET,
+                kakaoTokenRequest,
+                String.class
+        );
+        String responseBody = response.getBody();
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(responseBody);
+        Long kakaoId = jsonNode.get("id").asLong();
+        if(Objects.equals(member.getKakaoId(), kakaoId)) {
+            refreshTokenRepository.deleteByMember(member);
+            return new ResponseEntity<>(Message.success("로그아웃 되었습니다"), HttpStatus.OK);}
+        else throw new CustomException(ErrorCode.INVALID_TOKEN);
+    }
+
+
+    @Transactional
+    public ResponseEntity<?> deleteMemberInfo(HttpServletRequest request) throws JsonProcessingException {
+        Member member = check.accessTokenCheck(request);
+        Long memberId = member.getId();
+        memberRepository.deleteById(memberId);
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = kakaoTokenHeaderMaker(request);
+        RestTemplate rt = new RestTemplate();
+        ResponseEntity<String> response = rt.exchange(
+                "https://kapi.kakao.com/v1/user/unlink",
+                HttpMethod.GET,
+                kakaoTokenRequest,
+                String.class
+        );
+        String responseBody = response.getBody();
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(responseBody);
+        Long kakaoId = jsonNode.get("id").asLong();
+        if (Objects.equals(member.getKakaoId(), kakaoId)) {
+            refreshTokenRepository.deleteByMember(member);
+            return new ResponseEntity<>(Message.success(memberId + "번 회원탈퇴처리가 정상적으로 처리되었습니다"), HttpStatus.OK);
+        } else throw new CustomException(ErrorCode.INVALID_TOKEN);
+    }
+
+    public HttpEntity<MultiValueMap<String, String>> kakaoTokenHeaderMaker(HttpServletRequest request){
+        String accessToken = request.getHeader("Kakao_Authorization");
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        // HTTP 요청 보내기
+        return new HttpEntity<>(headers);
+    }
+
+
+
 }
 

--- a/src/main/java/com/hanghae/greenstep/kakaoShare/Dto/LinkDto.java
+++ b/src/main/java/com/hanghae/greenstep/kakaoShare/Dto/LinkDto.java
@@ -4,6 +4,6 @@ import lombok.Getter;
 
 @Getter
 public class LinkDto {
-    private String web_url;
+    private final String web_url ="https://greenstepapp.com";
     private String mobile_web_url;
 }

--- a/src/main/java/com/hanghae/greenstep/kakaoShare/Dto/SocialDto.java
+++ b/src/main/java/com/hanghae/greenstep/kakaoShare/Dto/SocialDto.java
@@ -1,8 +1,10 @@
 package com.hanghae.greenstep.kakaoShare.Dto;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class SocialDto {
 
     private Integer clapCount;

--- a/src/main/java/com/hanghae/greenstep/kakaoShare/KakaoShareService.java
+++ b/src/main/java/com/hanghae/greenstep/kakaoShare/KakaoShareService.java
@@ -13,6 +13,7 @@ import com.hanghae.greenstep.kakaoShare.Dto.KakaoTemplateDto;
 import com.hanghae.greenstep.kakaoShare.Dto.SocialDto;
 import com.hanghae.greenstep.shared.Message;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
@@ -24,31 +25,34 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class KakaoShareService {
 
     private final FeedRepository feedRepository;
 
     public ResponseEntity<?> shareKakaoToME(Long feedId, HttpServletRequest request) throws JsonProcessingException {
+        log.info("돈다");
         String accessToken = request.getHeader("Kakao_Authorization");
         HttpHeaders headers = new HttpHeaders();
         headers.add("Authorization", "Bearer " + accessToken);
         headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
-
+        log.info("헤더 생성완료");
         Feed feed = feedRepository.findById(feedId).orElseThrow( () -> new CustomException(ErrorCode.FEED_NOT_FOUND));
         KakaoTemplateDto kakaoTemplateDto = boxKakaoTemplate(feed,null);
-
+        log.info("곧 된다");
         MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
         body.add("template_object", kakaoTemplateDto);
         // HTTP 요청 보내기
          HttpEntity<MultiValueMap<String, Object>> kakaoShareRequest = new HttpEntity<>(body, headers);
         RestTemplate rt = new RestTemplate();
         ResponseEntity<String> response = rt.exchange(
-                "https://kapi.kakao.com/v2/api/talk/memo/default/send",
+                "https://kapi.kakao.com/v2/api/talk/memo/scrap/send" ,
                 HttpMethod.POST,
                 kakaoShareRequest,
                 String.class
         );
+        log.info("거의 성공");
         return getResponseEntity(response);
     }
 

--- a/src/main/java/com/hanghae/greenstep/member/Member.java
+++ b/src/main/java/com/hanghae/greenstep/member/Member.java
@@ -68,8 +68,6 @@ public class Member {
     @OneToMany(mappedBy = "member",cascade = CascadeType.ALL,orphanRemoval = true,fetch = FetchType.LAZY)
     private List<Feed> feedList;
 
-    @OneToMany(mappedBy = "member",cascade = CascadeType.ALL,orphanRemoval = true,fetch = FetchType.LAZY)
-    private Set<Clap> clapSet;
 
     @OneToMany(mappedBy = "member",cascade = CascadeType.ALL,orphanRemoval = true,fetch = FetchType.LAZY)
     private Set<MissionStatus> missionStatusSet;

--- a/src/main/java/com/hanghae/greenstep/member/MemberController.java
+++ b/src/main/java/com/hanghae/greenstep/member/MemberController.java
@@ -29,4 +29,6 @@ public class MemberController {
     public ResponseEntity<?> getProfileInfo(HttpServletRequest request){
         return memberService.getMemberInfo(request);
     }
+
+
 }

--- a/src/main/java/com/hanghae/greenstep/member/MemberService.java
+++ b/src/main/java/com/hanghae/greenstep/member/MemberService.java
@@ -10,10 +10,12 @@ import com.hanghae.greenstep.jwt.TokenProvider;
 import com.hanghae.greenstep.shared.Check;
 import com.hanghae.greenstep.shared.Message;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -77,4 +79,7 @@ public class MemberService {
         MemberResponseDto memberResponseDto = new MemberResponseDto(member);
         return new ResponseEntity<>(Message.success(memberResponseDto),HttpStatus.OK);
     }
+
+
+
 }


### PR DESCRIPTION
회원탈퇴 기능은 이후 DB 리셋 후 재 테스트 필요
clap의 member와의 연관관계 끊음으로서 연관관계 복잡성 연동성 완화 
그리고 탈퇴시에도 타 피드의 좋아요가 줄어들지 않도록 함.