### PR TITLE
fix: resource 디렉토리 생성 기능 삭제

### DIFF
--- a/.github/workflows/depoly.yml
+++ b/.github/workflows/depoly.yml
@@ -27,7 +27,6 @@ jobs:
         
       - name: make application.properties
         run:
-          mkdir ./src/main/resources | 
           touch ./src/main/resources/application.properties 
         shell: bash
         


### PR DESCRIPTION
resource 디렉토리가 깃허브내에 저장되었기에 생성기능 자체 삭제