### PR TITLE
fix: 관리자 인가시 보내는 알림창의 imgUrl null값으로 변경

### DIFF
--- a/src/main/java/com/hanghae/greenstep/admin/AdminService.java
+++ b/src/main/java/com/hanghae/greenstep/admin/AdminService.java
@@ -108,8 +108,8 @@ public class AdminService {
         String Url = "https://www.greenstepapp.com/mypage";
         //댓글 생성 시 모집글 작성 유저에게 실시간 알림 전송 ,
         String content = "["+submitMission.getMission().getMissionName()+"]미션 인증이 완료되었습니다. 지금 바로 피드에 공유해보세요!";
-        String imgUrl = "nullImg";
-        notificationService.send(submitMission.getMember(), NotificationType.APPROVE, content, Url, imgUrl);
+        String imgUrl = null;
+        notificationService.send(submitMission.getMember(), NotificationType.APPROVE, content, Url, null);
 
         return new SubmitMissionResponseDto(submitMission);
     }


### PR DESCRIPTION
#127 