### PR TITLE
fix: 알림 삭제 시 exception 처리 피드 오류로 되어있는 걸 알림 오류로 수정

### DIFF
--- a/src/main/java/com/hanghae/greenstep/notice/NotificationService.java
+++ b/src/main/java/com/hanghae/greenstep/notice/NotificationService.java
@@ -211,7 +211,7 @@ public class NotificationService {
     public ResponseEntity<Object> deleteByNotifications(Long[] notificationIdList) {
         for(Long notificationId : notificationIdList) {
             Notification notification = notificationRepository.findById(notificationId).orElseThrow(
-                    () -> new CustomException(ErrorCode.FEED_NOT_FOUND)
+                    () -> new CustomException(ErrorCode.NOT_EXIST_NOTIFICATION)
             );
             notificationRepository.delete(notification);
         }


### PR DESCRIPTION
#127 